### PR TITLE
ADD: functions and capabilitites that automatically initialize the boundary power flow variables.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Fixed implementation of polynomial nl costs above quadratic in `objective.jl`.
 - Bumped PMITD compatibility of `IM`, `PMD` and `PM` to the latest versions (i.e., V0.7.7, v0.14.9, and v0.19.9).
+- Added functions and capabilitites that automatically initialize the boundary power flow variables (i.e., `pbound_fr`, `pbound_to`, `qbound_fr`, and `qbound_to`).
+- `p/qbound_fr` variables are initialized based on the data parsed from the tranmission system data.
+- `p/qbound_to` variables are initialized by adding all the loads in the respective distribution systems and dividing them by 3 (assuming the initial state of the distribution system is balanced).
+- Refactored multiple functions in `ref.jl` to avoid unnecesary loops. These unnecesary loops were making the refs processes unccessary long.
 
 ## v0.7.7
 

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -53,7 +53,7 @@ function variable_boundary_power_real_to(pm::AbstractPowerModelITD; nw::Int=nw_i
     # creating the variables
     pbound_to = Dict{Any,Any}((l,j,i) => JuMP.@variable(pm.model,
             [c in connections[(l,j,i)]], base_name="$(nw)_pbound_to_$((l,j,i))",
-            start = _PMD.comp_start_value(ref(pm, nw, :boundary, l), "pbound_to_start", c, 0.0)
+            start = _PMD.comp_start_value(ref(pm, nw, :boundary, l), "pbound_to_start", c)
         ) for (l,j,i) in ref(pm, nw, :arcs_boundary_to)
     )
 
@@ -93,7 +93,7 @@ function variable_boundary_power_imaginary_to(pm::AbstractPowerModelITD; nw::Int
     # creating the variables
     qbound_to = Dict{Any,Any}((l,j,i) => JuMP.@variable(pm.model,
             [c in connections[(l,j,i)]], base_name="$(nw)_qbound_to_$((l,j,i))",
-            start = _PMD.comp_start_value(ref(pm, nw, :boundary, l), "qbound_to_start", c, 0.0)
+            start = _PMD.comp_start_value(ref(pm, nw, :boundary, l), "qbound_to_start", c)
         ) for (l,j,i) in ref(pm, nw, :arcs_boundary_to)
     )
 

--- a/test/data/transmission/pglib_opf_case500_goc.m
+++ b/test/data/transmission/pglib_opf_case500_goc.m
@@ -1733,15 +1733,15 @@ mpc.branch = [
 % INFO    : === Translation Options ===
 % INFO    : Phase Angle Bound:           30.0 (deg.)
 % INFO    : Setting Flat Start
-% INFO    : 
+% INFO    :
 % INFO    : === Generator Bounds Update Notes ===
-% INFO    : 
+% INFO    :
 % INFO    : === Base KV Replacement Notes ===
-% INFO    : 
+% INFO    :
 % INFO    : === Transformer Setting Replacement Notes ===
-% INFO    : 
+% INFO    :
 % INFO    : === Line Capacity Monotonicity Notes ===
-% INFO    : 
+% INFO    :
 % INFO    : === Voltage Setpoint Replacement Notes ===
 % INFO    : Bus 1	: V=0.98540926462, theta=-8.36784152229 -> V=1.0, theta=0.0
 % INFO    : Bus 2	: V=0.974020345007, theta=-11.1447179681 -> V=1.0, theta=0.0
@@ -2243,7 +2243,7 @@ mpc.branch = [
 % INFO    : Bus 498	: V=1.00866690287, theta=-2.66209509196 -> V=1.0, theta=0.0
 % INFO    : Bus 499	: V=1.00340669673, theta=-3.59395611678 -> V=1.0, theta=0.0
 % INFO    : Bus 500	: V=1.003371832, theta=-3.59691858681 -> V=1.0, theta=0.0
-% INFO    : 
+% INFO    :
 % INFO    : === Generator Setpoint Replacement Notes ===
 % INFO    : Gen at bus 272	: Pg=46.8993571031, Qg=18.0091132505 -> Pg=34.463, Qg=7.856
 % INFO    : Gen at bus 272	: Vg=1.0343582 -> Vg=1.0
@@ -2640,5 +2640,5 @@ mpc.branch = [
 % INFO    : Gen at bus 499	: Vg=1.039689 -> Vg=1.0
 % INFO    : Gen at bus 499	: Pg=1.73259069124, Qg=0.665908015041 -> Pg=1.2695, Qg=0.2905
 % INFO    : Gen at bus 499	: Vg=1.039689 -> Vg=1.0
-% INFO    : 
+% INFO    :
 % INFO    : === Writing Matpower Case File Notes ===

--- a/test/io.jl
+++ b/test/io.jl
@@ -22,7 +22,6 @@
         @test haskey(pmitd_data["it"], _PMD.pmd_it_name)
     end
 
-
     @testset "parse_link_file (invalid extension)" begin
         path = joinpath(dirname(dist_path), "case3_balanced.raw")
         @test_throws ErrorException parse_link_file(path)

--- a/test/opfitd.jl
+++ b/test/opfitd.jl
@@ -18,7 +18,6 @@
         @test result["termination_status"] == LOCALLY_SOLVED
     end
 
-
     @testset "solve_model (with network inputs): Balanced case5-case3 ACR-ACR with polynomial nl terms" begin
         pm_file = joinpath(dirname(trans_path), "case5_withload.m")
         pmd_file = joinpath(dirname(dist_path), "case3_balanced.dss")
@@ -127,7 +126,6 @@
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 18005.97151; atol = 1e-4)
     end
-
 
     @testset "solve_model (with network inputs): Balanced case5-case13 ACR-ACR Without Dist. Generator ACR-ACR" begin
         pm_file = joinpath(dirname(trans_path), "case5_withload_ieee13.m")
@@ -294,7 +292,6 @@
         @test isapprox(result["objective"], 18005.97151; atol = 1e-4)
     end
 
-
     @testset "solve_model (with network inputs): Balanced case5-case3 IVR-IVR with polynomial nl terms" begin
         pm_file = joinpath(dirname(trans_path), "case5_withload.m")
         pmd_file = joinpath(dirname(dist_path), "case3_balanced.dss")
@@ -320,7 +317,7 @@
         @test result["termination_status"] == LOCALLY_SOLVED
     end
 
-     @testset "solve_model (with network inputs): Balanced case5-case3 IVR-IVR with piecewise linear terms" begin
+    @testset "solve_model (with network inputs): Balanced case5-case3 IVR-IVR with piecewise linear terms" begin
         pm_file = joinpath(dirname(trans_path), "case5_pwlc_withload.m")
         pmd_file = joinpath(dirname(dist_path), "case3_balanced.dss")
         pmitd_file = joinpath(dirname(bound_path), "case5_case3_bal.json")

--- a/test/opfitd_hybrids.jl
+++ b/test/opfitd_hybrids.jl
@@ -42,7 +42,6 @@
         @test result["termination_status"] == LOCALLY_SOLVED
     end
 
-
     @testset "solve_model (with network inputs): Unbalanced case5-case3 Without Dist. Generator BFA-LinDist3FlowPowerModel" begin
         pm_file = joinpath(dirname(trans_path), "case5_withload.m")
         pmd_file = joinpath(dirname(dist_path), "case3_unbalanced_withoutgen.dss")
@@ -62,7 +61,6 @@
         result = solve_model(pmitd_data, pmitd_type, scs_solver, build_opfitd)
         @test result["termination_status"] == OPTIMAL
     end
-
 
     @testset "solve_model (with network inputs): Balanced case5-case3 Without Dist. Generator SDPWRM-SOCConicUBF" begin
         pm_file = joinpath(dirname(trans_path), "case5_withload.m")

--- a/test/opfitd_mn.jl
+++ b/test/opfitd_mn.jl
@@ -32,7 +32,6 @@
         @test isapprox(result["objective"], 58399.9993; atol = 1e-4)
     end
 
-
     @testset "solve_mn_opfitd: Multinetwork case5-case3 x2 Without Dist. Generator ACP-ACP" begin
         pm_file = joinpath(dirname(trans_path), "case5_with2loads.m")
         pmd_file1 = joinpath(dirname(dist_path), "case3_unbalanced_withoutgen_mn.dss")

--- a/test/opfitd_ms.jl
+++ b/test/opfitd_ms.jl
@@ -101,7 +101,6 @@
         @test all(isapprox.(result["solution"]["it"]["pmd"]["bus"]["3bus_bal_nogen.primary"]["va"][2], -121.0428; atol=1e-3))
     end
 
-
     @testset "solve_model opfitd (with network inputs): Multi-System Balanced case5-case3x2 With PV ACP-ACP" begin
         pm_file = joinpath(dirname(trans_path), "case5_with2loads.m")
         pmd_file1 = joinpath(dirname(dist_path), "case3_balanced_withPV.dss")

--- a/test/opfitd_solution.jl
+++ b/test/opfitd_solution.jl
@@ -15,7 +15,6 @@
         @test all(isapprox.(result["solution"]["it"]["pmd"]["bus"]["3bus_unbal.primary"]["vm"][1], 0.9352; atol=1e-3))
     end
 
-
     @testset "solve_model (with network inputs): Balanced case5-case3 Without Dist. Generator IVR-IVR" begin
         pm_file = joinpath(dirname(trans_path), "case5_withload.m")
         pmd_file = joinpath(dirname(dist_path), "case3_balanced_withoutgen.dss")

--- a/test/pfitd.jl
+++ b/test/pfitd.jl
@@ -68,7 +68,6 @@
     #     @test result["termination_status"] == LOCALLY_SOLVED
     # end
 
-
     @testset "solve_pfitd (with network inputs): Unbalanced case5-case3 With Dist. Generator SOCBF-SOCNLPUBF" begin
         pm_file = joinpath(dirname(trans_path), "case5_withload.m")
         pmd_file = joinpath(dirname(dist_path), "case3_unbalanced_notransformer.dss")

--- a/test/pfitd_hybrids.jl
+++ b/test/pfitd_hybrids.jl
@@ -22,7 +22,6 @@
         @test result["termination_status"] == LOCALLY_SOLVED
     end
 
-
     ## This unit test has been disabled due to the test failing in all CI Julia 1-latest runs due to NUMERICAL_ERROR (Windows)
     # @testset "solve_model (with network inputs): Unbalanced case5-case3 Without Dist. Generator ACR-FOTP" begin
     #     pm_file = joinpath(dirname(trans_path), "case5_withload.m")

--- a/test/transformations_opfitd.jl
+++ b/test/transformations_opfitd.jl
@@ -20,7 +20,6 @@
         @test result["termination_status"] == LOCALLY_SOLVED
     end
 
-
     @testset "solve_model (with network inputs): Balanced case5-case3 Without Dist. Generator ACR-ACR - Remove all bounds" begin
         pm_file = joinpath(dirname(trans_path), "case5_withload.m")
         pmd_file = joinpath(dirname(dist_path), "case3_balanced_withoutgen.dss")
@@ -37,7 +36,6 @@
         result = solve_model(pmitd_data, pmitd_type, ipopt, build_opfitd)
         @test result["termination_status"] == LOCALLY_SOLVED
     end
-
 
     @testset "solve_model (with network inputs): Balanced case5-case3 Without Dist. Generator ACR-ACR - Apply Kron reduction and phase projections" begin
         pm_file = joinpath(dirname(trans_path), "case5_withload.m")


### PR DESCRIPTION
- Added functions and capabilitites that automatically initialize the boundary power flow variables (i.e., `pbound_fr`, `pbound_to`, `qbound_fr`, and `qbound_to`).
- `p/qbound_fr` variables are initialized based on the data parsed from the transmission system data.
- `p/qbound_to` variables are initialized by adding all the loads in the respective distribution systems and dividing them by 3 (assuming the initial state of the distribution system is balanced).
- Refactored multiple functions in `ref.jl` to avoid unnecessary loops. These unnecessary loops were making the refs processes unnecessary long.
