### PR TITLE
fix parse_file and _rename_network_components! to support matlab files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # PowerModelsITD.jl Change Log
 
+## [unreleased] 2025-10-16
+- Update the functions `parse_files`, `parse_power_distribution_file` (in `common.jl`) and the functions `_rename_components!` and `_rename_network_components!` (in `helpers.jl`) to work for the distribution input files in the matpower versions.
+
 ## staged
 
 - none.

--- a/src/core/helpers.jl
+++ b/src/core/helpers.jl
@@ -207,6 +207,40 @@ function _remove_network_components!(base_data::Dict{String,<:Any})
 
 end
 
+""" 
+    function _safe_prefix!(
+        obj::Dict{String,<:Any}, 
+        key::String, ckt_name::String; 
+        fallback_key::String=key
+        )
+
+Set the rules of renaming some components (i.e. `source_id` and `bus`). `obj` is the dictionary layer
+where the renamed components are to be added. `key` is the component name, `fallback_key` is the 
+alternative component name that might appear in matlab files. 
+"""
+
+function _safe_prefix!(obj::Dict{String,<:Any}, key::String, ckt_name::String; fallback_key::String=key)
+    
+    if haskey(obj, key)
+        val = obj[key]
+    elseif haskey(obj, fallback_key)
+        val = obj[fallback_key]
+    else
+        return
+    end 
+
+    if isa(val, String) || isa(val, Number)
+        obj[key] = ckt_name * "." * string(val) 
+    elseif isa(val, Vector)
+        val_ = deepcopy(val)
+        if length(val_) >= 1
+            obj[key] = ckt_name * "." * string(val_[2])
+        end 
+    else 
+        obj[key] = val
+    end 
+end
+
 
 """
     function _rename_network_components!(
@@ -221,27 +255,6 @@ components are to be added, `data` is the dictionary containing the components t
 with matlab files.
 """
 function _rename_network_components!(base_data::Dict{String,<:Any}, data::Dict{String,<:Any}, ckt_name::String)
-
-    function _safe_prefix!(obj::Dict{String,<:Any}, key::String, ckt_name::String; fallback_key::String=key)
-        if haskey(obj, key)
-            val = obj[key]
-        elseif haskey(obj, fallback_key)
-            val = obj[fallback_key]
-        else
-            return
-        end 
-
-        if isa(val, String) || isa(val, Number)
-            obj[key] = ckt_name * "." * string(val) 
-        elseif isa(val, Vector)
-            val_ = deepcopy(val)
-            if length(val_) >= 1
-                obj[key] = ckt_name * "." * string(val_[2])
-            end 
-        else 
-            obj[key] = val
-        end 
-    end
 
     # loop through buses
     if (haskey(data, "bus"))

--- a/src/core/helpers.jl
+++ b/src/core/helpers.jl
@@ -217,9 +217,31 @@ end
 
 Rename specific components in single network dictionary. `base_data` is the dictionary where the renamed
 components are to be added, `data` is the dictionary containing the components to be renamed.
-`ckt_name` is the circuit name of `data`.
+`ckt_name` is the circuit name of `data`. Update the function to work for distribution networks 
+with matlab files.
 """
 function _rename_network_components!(base_data::Dict{String,<:Any}, data::Dict{String,<:Any}, ckt_name::String)
+
+    function _safe_prefix!(obj::Dict{String,<:Any}, key::String, ckt_name::String; fallback_key::String=key)
+        if haskey(obj, key)
+            val = obj[key]
+        elseif haskey(obj, fallback_key)
+            val = obj[fallback_key]
+        else
+            return
+        end 
+
+        if isa(val, String) || isa(val, Number)
+            obj[key] = ckt_name * "." * string(val) 
+        elseif isa(val, Vector)
+            val_ = deepcopy(val)
+            if length(val_) >= 1
+                obj[key] = ckt_name * "." * string(val_[2])
+            end 
+        else 
+            obj[key] = val
+        end 
+    end
 
     # loop through buses
     if (haskey(data, "bus"))
@@ -297,10 +319,13 @@ function _rename_network_components!(base_data::Dict{String,<:Any}, data::Dict{S
             if !(haskey(base_data, "load"))
                 base_data["load"] = Dict()
             end
+
             base_data["load"][new_key] = value
-            base_data["load"][new_key]["source_id"] = ckt_name * "." * base_data["load"][new_key]["source_id"]
-            base_data["load"][new_key]["bus"] = ckt_name * "." * base_data["load"][new_key]["bus"]
             base_data["load"][new_key]["belongs_to_ckt"] = ckt_name  # add new category "belongs_to_ckt" to every component
+
+            _safe_prefix!(base_data["load"][new_key], "source_id", ckt_name)
+            _safe_prefix!(base_data["load"][new_key], "bus", ckt_name; fallback_key="load_bus")
+
         end
     end
 
@@ -333,17 +358,18 @@ function _rename_network_components!(base_data::Dict{String,<:Any}, data::Dict{S
     end
 
     # loop through generators
-    if (haskey(data, "generator"))
-        for (key, value) in data["generator"]
+    if (haskey(data, "generator")) || haskey(data, "gen")
+        gen_name = get(data, "generator", "gen")
+        for (key, value) in data[gen_name]
             new_key = ckt_name * "." * key
             # if key does not exists in base_data, add an empty Dict
             if !(haskey(base_data, "generator"))
                 base_data["generator"] = Dict()
             end
             base_data["generator"][new_key] = value
-            base_data["generator"][new_key]["source_id"] = ckt_name * "." * base_data["generator"][new_key]["source_id"]
-            base_data["generator"][new_key]["bus"] = ckt_name * "." * base_data["generator"][new_key]["bus"]
             base_data["generator"][new_key]["belongs_to_ckt"] = ckt_name  # add new category "belongs_to_ckt" to every component
+            _safe_prefix!(base_data["generator"][new_key], "source_id", ckt_name)
+            _safe_prefix!(base_data["generator"][new_key], "bus", ckt_name; fallback_key="gen_bus")
         end
     end
 
@@ -356,9 +382,12 @@ function _rename_network_components!(base_data::Dict{String,<:Any}, data::Dict{S
                 base_data["shunt"] = Dict()
             end
             base_data["shunt"][new_key] = value
-            base_data["shunt"][new_key]["source_id"] = ckt_name * "." * base_data["shunt"][new_key]["source_id"]
-            base_data["shunt"][new_key]["bus"] = ckt_name * "." * base_data["shunt"][new_key]["bus"]
+
             base_data["shunt"][new_key]["belongs_to_ckt"] = ckt_name  # add new category "belongs_to_ckt" to every component
+
+            _safe_prefix!(base_data["shunt"][new_key], "source_id", ckt_name)
+            _safe_prefix!(base_data["shunt"][new_key], "bus", ckt_name; fallback_key="shunt_bus")
+
         end
     end
 
@@ -394,7 +423,7 @@ function _rename_network_components!(base_data::Dict{String,<:Any}, data::Dict{S
 
     # add vbases to settings
     # loop through settings
-    if (haskey(data, "settings"))
+    if (haskey(data, "settings")) && (haskey(data["settings"], "vbases_default"))
         for (key, value) in data["settings"]["vbases_default"]
             new_key = ckt_name * "." * key
             base_data["settings"]["vbases_default"][new_key] = value
@@ -402,7 +431,6 @@ function _rename_network_components!(base_data::Dict{String,<:Any}, data::Dict{S
     end
 
 end
-
 
 """
     function _add_file_name!(

--- a/src/core/helpers.jl
+++ b/src/core/helpers.jl
@@ -358,9 +358,16 @@ function _rename_network_components!(base_data::Dict{String,<:Any}, data::Dict{S
     end
 
     # loop through generators
-    if (haskey(data, "generator")) || haskey(data, "gen")
-        gen_name = get(data, "generator", "gen")
-        for (key, value) in data[gen_name]
+    if haskey(data, "generator")
+        gen_key = "generator"
+    elseif haskey(data, "gen")
+        gen_key = "gen"
+    else
+        gen_key = nothing
+    end
+
+    if !isnothing(gen_key)
+        for (key, value) in data[gen_key]
             new_key = ckt_name * "." * key
             # if key does not exists in base_data, add an empty Dict
             if !(haskey(base_data, "generator"))

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -141,7 +141,13 @@ function parse_power_distribution_file(pmd_file::String, base_data::Dict{String,
     # Read distribution network data.
     if split(pmd_file, ".")[end] == "m" # If reading a MATPOWER file.
         data = _PM.parse_file(pmd_file)
+
+        if !haskey(data, "settings")
+            data["settings"] = Dict{String, Any}()
+        end 
+        
         data["name"] = String(get(data, "name", split(basename(pmd_file), ".")[1]))
+        data["settings"]["power_scale_factor"] = 1/data["baseMVA"]
         _scale_loads!(data, inv(3.0))
         _PMD.make_multiconductor!(data, real(3))
     else # Otherwise, use the PowerModelsDistribution parser.

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -141,6 +141,7 @@ function parse_power_distribution_file(pmd_file::String, base_data::Dict{String,
     # Read distribution network data.
     if split(pmd_file, ".")[end] == "m" # If reading a MATPOWER file.
         data = _PM.parse_file(pmd_file)
+        data["name"] = String(get(data, "name", split(basename(pmd_file), ".")[1]))
         _scale_loads!(data, inv(3.0))
         _PMD.make_multiconductor!(data, real(3))
     else # Otherwise, use the PowerModelsDistribution parser.

--- a/test/data/distribution/case3_balanced_withoutgen.m
+++ b/test/data/distribution/case3_balanced_withoutgen.m
@@ -1,0 +1,33 @@
+% Generated from the OpenDSS file, case3_balanced_withoutgen
+
+function mpc = case3_bal_nogen
+mpc.version = '2';
+mpc.baseMVA = 100;
+
+%% bus data
+%  bus_i type Pd Qd  Gs Bs area Vm Va baseKV zone Vmax Vmin
+mpc.bus = [
+	1	3	0	    0	   0	0	1	1.00	0	230	1	1.05	0.95;
+	2	1	100	    60	   0	0	1	1.00	0	230	1	1.05	0.95;
+	3	1	90	    40	   0	0	1	1.00	0	230	1	1.05	0.95;
+];
+
+%% generator data
+%  bus	Pg	Qg	Qmax	Qmin	Vg	mBase	status	Pmax	Pmin
+mpc.gen = [
+	1	0	0	300	-300	1.00	100	1	300	0;
+];
+
+%% branch data
+%  fbus tbus	r	x	b	rateA rateB rateC	ratio	angle	status	angmin	angmax
+mpc.branch = [
+	1	2	0.010	0.085	0.176	250	250	250	0	0	1	-360	360;
+	1	3	0.017	0.092	0.158	250	250	250	0	0	1	-360	360;
+	2	3	0.032	0.161	0.306	150	150	150	0	0	1	-360	360;
+];
+
+%% generator cost data
+% 2 startup shutdown n c(n-1) ... c0
+mpc.gencost = [
+	2	0	0	3	0.02	2	0;
+];

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,4 +45,5 @@ PowerModelsITD.silence!()
     include("opfitd_storage_linear.jl")
     include("solve_x.jl")
     include("pfitd_mn.jl")
+    include("test_matlab.jl")
 end

--- a/test/test_matlab.jl
+++ b/test/test_matlab.jl
@@ -1,0 +1,12 @@
+using PowerModelsITD
+using Test
+
+@testset "Matlab File Parsing" begin
+    pm_file = joinpath(dirname(trans_path), "case5_withload.m")
+    pmd_files = joinpath(dirname(dist_path), "case3_balanced_withoutgen.m")
+    boundary_file = joinpath(dirname(bound_path), "case5_case3_bal_nogen.json") 
+
+    data = PowerModelsITD.parse_files(pm_file, pmd_files, boundary_file)
+
+    @test haskey(data["it"], "pm")
+end


### PR DESCRIPTION
# Pull Request (PR) for Distribution Network Data with MATPOWER Files

When using PowerModelsITD to parse MATLAB (.m) distribution network files, there were issues preventing direct conversion. Specifically:

1. `parse_file` did not handle the format of certain components correctly. For example. `data["name"]` in MATPOWER files is often in the format of SubString{String} rather than String.

2. `_rename_network_components!` did not handle the format of certain components correctly. For example, for load/shunt components, `source_id` can be a `Vector{Any}`, which caused the error:
     ```
     *(::String, ::Vector{Any})
     ```
These made it impossible to load MATLAB-based distribution networks directly.

---

### Changes
1. Updated `_rename_network_components!` to safely handle `source_id`, `bus`, and related fields when they are `Vector{Any}`, numbers, or strings.
4. Ensured MATLAB distribution files can now be parsed without triggering type errors.
5. Preserved all existing behavior for JSON/DSS files.

---

### Testing
- Verified that multiple `.m` distribution files can now be loaded via `parse_files(pm_file, pmd_files, boundary_file)` without errors.
- Existing unit tests pass.

---

### Notes
- This fix is backward-compatible with existing JSON and DSS distribution network inputs.
- No functional interface changes.
